### PR TITLE
fix(vite-react-19): css imports

### DIFF
--- a/packages/vite-react-19/src/main.tsx
+++ b/packages/vite-react-19/src/main.tsx
@@ -4,8 +4,8 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { Theme } from "./theme";
 
-import "@fontsource/inter";
-import "@repo/css-reset";
+import "@fontsource/inter/index.css";
+import "@repo/css-reset/index.css";
 
 const container = document.createElement("div");
 container.setAttribute("class", "my-app");


### PR DESCRIPTION

TypeScript 5.6 introduced a new option, [`noUncheckedSideEffectImports`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#the---nouncheckedsideeffectimports-option), which helps validate non-TypeScript files. This option is enabled starting from [`@tsconfig/vite-react@3.4.0`](https://www.npmjs.com/package/@tsconfig/vite-react/v/3.4.0). However, it does not work for files resolved using `package.json` configuration. As a result, we need to replace module names in import paths with their exact CSS file paths.

<img width="762" alt="image" src="https://github.com/user-attachments/assets/5cc28d8b-d6d7-4c81-a09d-424c17b988c7" />

<img width="762" alt="image" src="https://github.com/user-attachments/assets/3e7791ea-746a-4b8f-90e6-020e6c106e8d" />
