### PR TITLE
docs: update try online links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 My all-in-one template for web development.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/VdustR/template-aio)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/VdustR/template-aio)
 
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/Vdustr/template-aio)
-
-[![Open in IDX](https://cdn.idx.dev/btn/open_dark_32.svg)](https://idx.google.com/import?url=https%3A%2F%2Fgithub.com%2FVdustR%2Ftemplate-aio)
+<a href="https://studio.firebase.google.com/import?url=">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://cdn.firebasestudio.dev/btn/open_dark_32.svg">
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://cdn.firebasestudio.dev/btn/open_light_32.svg">
+    <img
+      height="32"
+      alt="Open in Firebase Studio"
+      src="https://cdn.firebasestudio.dev/btn/open_blue_32.svg">
+  </picture>
+</a>
 
 ## License
 


### PR DESCRIPTION
As title.

# Copilot

This pull request updates the `README.md` file to replace outdated links for development environments and add a new option for opening the project in Firebase Studio.

Updates to development environment links:

* Replaced the "Open in StackBlitz" link with a link to open the project in GitHub Codespaces, including an updated badge image.
* Removed the "Open in CodeSandbox" and "Open in IDX" links, along with their associated badge images.
* Added a new option to open the project in Firebase Studio, with support for light and dark mode badge images.