### PR TITLE
chore(code): disable source.removeUnusedImports for mdx

### DIFF
--- a/template-aio.code-workspace
+++ b/template-aio.code-workspace
@@ -16,6 +16,13 @@
     { "path": "packages/vite-react-19" },
   ],
   "settings": {
+    "[mdx]": {
+      "editor.codeActionsOnSave": [
+        "source.fixAll.eslint",
+        "source.fixAll.stylelint",
+        "source.formatDocument",
+      ],
+    },
     "css.validate": false,
     "editor.codeActionsOnSave": [
       "source.removeUnusedImports",


### PR DESCRIPTION

The imports won't be flagged as used in `.mdx`, disable `source.removeUnusedImports` to prevent unexpected removal.

# Copilot


This pull request makes a configuration update to the `template-aio.code-workspace` file to enhance the development experience by adding automatic code actions on save for `mdx` files.

Configuration updates:

* [`template-aio.code-workspace`](diffhunk://#diff-bcab26cac64dc26442ed0bb9224972efa668900f89e8f147efd0f96603c3b722R19-R25): Added a new setting for `"[mdx]"` to enable automatic code actions on save, including fixing ESLint and Stylelint issues and formatting the document.