### PR TITLE
chore: setup pnpm strict catalogMode

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac",
   "engines": {
     "node": ">=18",
     "pnpm": ">=8"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   vite-tsconfig-paths: ^5.1.4
   vitest: ^3.1.4
   vitest-browser-react: ^0.2.0
+catalogMode: strict
 onlyBuiltDependencies:
   - esbuild
   - unrs-resolver


### PR DESCRIPTION

# Copilot

This pull request includes updates to the package manager version and configuration changes to the `pnpm-workspace.yaml` file. These changes aim to improve dependency management and enforce stricter catalog settings.

Dependency management updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L71-R71): Updated the `packageManager` field to use `pnpm@10.12.1` with a specific SHA512 checksum for improved security and version control.

Configuration changes:

* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR56): Added a new `catalogMode` field set to `strict`, enforcing stricter catalog settings for dependency resolution.