### PR TITLE
chore: prettierignore LINCENSE

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 dist
 /.changeset
 CHANGELOG.md
+LICENSE


### PR DESCRIPTION

# Copilot

This pull request makes a small update to the `.prettierignore` file by adding the `LICENSE` file to the list of ignored files.