### PR TITLE
build(template-ts-lib): fix bundle

### DIFF
--- a/.changeset/late-hats-behave.md
+++ b/.changeset/late-hats-behave.md
@@ -1,0 +1,6 @@
+---
+"@repo/template-vite-react-19": patch
+"@vdustr/template-aio-ts-lib": patch
+---
+
+fix template-ts-lib bundle

--- a/packages/template-ts-lib/package.json
+++ b/packages/template-ts-lib/package.json
@@ -4,20 +4,6 @@
   "description": "A template for developing libraries",
   "license": "MIT",
   "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
-    "./LICENSE": "./LICENSE",
-    "./README.md": "./README.md",
-    "./package": "./package.json",
-    "./package.json": "./package.json"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/template-ts-lib/tsdown.config.ts
+++ b/packages/template-ts-lib/tsdown.config.ts
@@ -3,9 +3,8 @@ import { defineConfig } from "tsdown";
 
 const basicConfig = {
   entry: ["src/index.ts"],
-  tsconfig: "tsconfig.app.json",
+  tsconfig: "tsconfig.lib.json",
   dts: true,
-  sourcemap: true,
 } as const satisfies Exclude<UserConfig, Array<any>>;
 
 export default defineConfig([

--- a/packages/template-vite-react-19/src/App.tsx
+++ b/packages/template-vite-react-19/src/App.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps, FC } from "react";
 import { Box, Button, Card, Typography } from "@mui/joy";
 import useEventCallback from "@mui/utils/useEventCallback";
 import { sxUtils } from "@utils/sx";
-import { add } from "@vdustr/template-aio-ts-lib/add";
+import { add } from "@vdustr/template-aio-ts-lib";
 import { useState } from "react";
 
 import { Layout } from "./layout";

--- a/packages/template-vite-react-19/tsconfig.app.json
+++ b/packages/template-vite-react-19/tsconfig.app.json
@@ -4,8 +4,7 @@
       "@utils/*": ["./src/utils/*"],
       "@vdustr/template-aio-ts-lib": [
         "../../packages/template-ts-lib/src/index.ts"
-      ],
-      "@vdustr/template-aio-ts-lib/*": ["../../packages/template-ts-lib/src/*"]
+      ]
     },
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
   },


### PR DESCRIPTION

# Copilot

This pull request includes several updates to improve the build configuration and dependency usage for the `template-ts-lib` and `template-vite-react-19` packages. The most significant changes involve fixing the `template-ts-lib` bundle, updating TypeScript configurations, and simplifying dependency imports in `template-vite-react-19`.

### Updates to `template-ts-lib`:

* Removed the `exports` field from `package.json` to simplify the package structure and resolve bundling issues. (`packages/template-ts-lib/package.json`, [packages/template-ts-lib/package.jsonL7-L20](diffhunk://#diff-57ab0babd63975615902a8c97e9a52e9a78df03a8ced70655bd5171ffbc691f3L7-L20))
* Updated the `tsdown.config.ts` file to use `tsconfig.lib.json` instead of `tsconfig.app.json` for better alignment with the library's build requirements. (`packages/template-ts-lib/tsdown.config.ts`, [packages/template-ts-lib/tsdown.config.tsL6-L8](diffhunk://#diff-c98b04284a1962fdf14a115b6b6a73c227372d3763241edb390ee40456878601L6-L8))

### Updates to `template-vite-react-19`:

* Simplified the import path for `@vdustr/template-aio-ts-lib` by removing the need for deep imports. (`packages/template-vite-react-19/src/App.tsx`, [packages/template-vite-react-19/src/App.tsxL6-R6](diffhunk://#diff-c8f7ba446d36f171ddfa3e3d7fe0253111a657d3f550b1a2a31dd777d0314000L6-R6))
* Removed the deep import alias for `@vdustr/template-aio-ts-lib/*` in `tsconfig.app.json` to streamline TypeScript path mappings. (`packages/template-vite-react-19/tsconfig.app.json`, [packages/template-vite-react-19/tsconfig.app.jsonL7-R7](diffhunk://#diff-91128d92d0c51f0e62748eb89090f3f913a99ebb840cbeee82d09918c1748864L7-R7))

### Miscellaneous:

* Added a changeset to document the patch-level fixes for both `template-ts-lib` and `template-vite-react-19`. (`.changeset/late-hats-behave.md`, [.changeset/late-hats-behave.mdR1-R6](diffhunk://#diff-43d55e1b5224e21beca5eadc6808ee25d70cc488c00b817a9a3ccd6f94ef2f9cR1-R6))