### PR TITLE
ci: add .npmrc creation step for GitHub Packages authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Remove this if publishing to npm instead of GitHub Packages
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+          EOF
+
       - name: Release
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
# Copilot

This pull request updates the GitHub Actions workflow for releases by adding a step to configure `.npmrc` for publishing to GitHub Packages.

Workflow configuration changes:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R38-R44): Added a step to create a `.npmrc` file using the `GITHUB_TOKEN` secret. This step is necessary for authenticating with GitHub Packages. A comment clarifies that this step should be removed if publishing to npm instead.