### PR TITLE
ci: changesets release commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
+          commit: "build: bump version"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Copilot

This pull request includes a small update to the `.github/workflows/release.yml` file. The change adds a `commit` parameter to the `changesets/action` step, specifying a commit message for version bumps.

- [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R50): Added `commit: "build: bump version"` to the `changesets/action` configuration.