### PR TITLE
build(template-vite-react-19): remove redundant assertion

### DIFF
--- a/.changeset/soft-buses-talk.md
+++ b/.changeset/soft-buses-talk.md
@@ -1,0 +1,5 @@
+---
+"@repo/template-vite-react-19": patch
+---
+
+remove redundant assertion

--- a/packages/template-vite-react-19/vite.config.ts
+++ b/packages/template-vite-react-19/vite.config.ts
@@ -1,4 +1,3 @@
-import type { PluginOption } from "vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -7,7 +6,7 @@ export default defineConfig({
   plugins: [
     tsconfigPaths({
       projects: ["./tsconfig.app.json"],
-    }) as unknown as PluginOption,
+    }),
     react({
       babel: {
         plugins: [["babel-plugin-react-compiler"]],


### PR DESCRIPTION

As title.

# Copilot

This pull request includes changes to the `template-vite-react-19` package, focusing on simplifying the `vite.config.ts` file and removing redundant code.

### Configuration simplifications:
* [`packages/template-vite-react-19/vite.config.ts`](diffhunk://#diff-6ea8343629ec436de7d820e4b49d74e5649c24d953db96ab5a82ba6c1d2e674bL10-R9): Removed the explicit type casting (`as unknown as PluginOption`) from the `tsconfigPaths` plugin configuration to simplify the code.

### Code cleanup:
* [`.changeset/soft-buses-talk.md`](diffhunk://#diff-4dc319b8ad77472999fc13021ab2ffbb3f9acded8aebac62e5bab00505f17c10R1-R5): Added a changeset file documenting the removal of a redundant assertion in the codebase.

### Dependency adjustments:
* [`packages/template-vite-react-19/vite.config.ts`](diffhunk://#diff-6ea8343629ec436de7d820e4b49d74e5649c24d953db96ab5a82ba6c1d2e674bL1): Removed the unused import of `PluginOption` from the `vite` package.