### PR TITLE
ci: delete all except only latest version of template-aio-ts-lib

### DIFF
--- a/.changeset/wild-falcons-dream.md
+++ b/.changeset/wild-falcons-dream.md
@@ -1,0 +1,5 @@
+---
+"@vdustr/template-aio-ts-lib": patch
+---
+
+delete all except only latest version of template-aio-ts-lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,16 @@ jobs:
           commit: "build: bump version"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-type: npm
+          package-name: template-aio-ts-lib
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-versions-to-keep: 1
+        # Allow to continue even if the package is not found.
+        #
+        # ```
+        # Error: delete version API failed. Package not found.
+        # ```
+        continue-on-error: true


### PR DESCRIPTION

As title.

# Copilot

This pull request introduces changes to manage package versions for `template-aio-ts-lib` by ensuring only the latest version is kept. It includes updates to the workflow configuration and documentation.

### Package version management:

* [`.changeset/wild-falcons-dream.md`](diffhunk://#diff-d2c7117af070b39e4e108d2714a14890f2d4dbf13161653c058f31d337c074f8R1-R5): Added a changeset indicating a patch update for `template-aio-ts-lib` and specifying that only the latest version of the package should be retained.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R54-R66): Updated the release workflow to use the `actions/delete-package-versions` action. This ensures older versions of the `template-aio-ts-lib` package are deleted, keeping only the most recent version. The action is configured to continue without failing if the package is not found.