### PR TITLE
ci: keep-one-ts-lib as individual job

### DIFF
--- a/.changeset/red-walls-train.md
+++ b/.changeset/red-walls-train.md
@@ -1,0 +1,5 @@
+---
+"@vdustr/template-aio-ts-lib": patch
+---
+
+keep-one-ts-lib as individual job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -52,6 +54,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  keep-one-ts-lib:
+    name: Keep only one version of template-aio-ts-lib
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-22.04
+    steps:
       - uses: actions/delete-package-versions@v5
         with:
           package-type: npm


### PR DESCRIPTION
# Copilot

This pull request introduces a new workflow job to manage package versions and updates the release workflow to include outputs for published changes. Additionally, it adds a changeset file to document the patch version update for the `@vdustr/template-aio-ts-lib` package.

### Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R14-R15): Added an output named `published` to the `release` job to track whether changesets were published.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R57-R62): Introduced a new job, `keep-one-ts-lib`, which depends on the `release` job and ensures only one version of the `template-aio-ts-lib` package is kept. This job runs conditionally based on the `published` output.

### Changeset addition:

* [`.changeset/red-walls-train.md`](diffhunk://#diff-b7b5ab2ab4133ea4027041437988d42b04c8777298f4714111f6e750a66df3aeR1-R5): Added a changeset file to document the patch update for `@vdustr/template-aio-ts-lib`.