### PR TITLE
chore: ignore all local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,5 +141,5 @@ dist
 
 !.env
 !.env.*
-.env.local
-.env.*.local
+*.local
+*.local.*

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -147,8 +147,8 @@ dist
 
 !.env
 !.env.*
-.env.local
-.env.*.local
+*.local
+*.local.*
 
 /pnpm-lock.yaml
 dist


### PR DESCRIPTION
This pull request updates the `.stylelintignore` file to simplify the way local environment files are ignored. The change generalizes the ignore patterns for local files.

Ignore pattern simplification:

* Replaced `.env.local` and `.env.*.local` with `*.local` and `*.local.*` to more broadly ignore any local environment files.