### PR TITLE
chore: update copyright year to 2026 and use HTTPS URLs

### DIFF
--- a/.changeset/violet-games-drum.md
+++ b/.changeset/violet-games-drum.md
@@ -1,0 +1,5 @@
+---
+"@vdustr/template-aio-ts-lib": patch
+---
+
+Update copyright year to 2026 and use HTTPS for URLs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 ViPro <vdustr@gmail.com> (http://vdustr.dev)
+Copyright (c) 2024-2026 ViPro <vdustr@gmail.com> (https://vdustr.dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Contributions are welcome! Please read the [contributing guide](https://github.c
 
 [MIT](./LICENSE)
 
-Copyright (c) 2024-2025 ViPro <vdustr@gmail.com> (<http://vdustr.dev>)
+Copyright (c) 2024-2026 ViPro <vdustr@gmail.com> (<https://vdustr.dev>)

--- a/packages/template-ts-lib/LICENSE
+++ b/packages/template-ts-lib/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 ViPro <vdustr@gmail.com> (http://vdustr.dev)
+Copyright (c) 2024-2026 ViPro <vdustr@gmail.com> (https://vdustr.dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/template-ts-lib/README.md
+++ b/packages/template-ts-lib/README.md
@@ -6,4 +6,4 @@ A template for developing libraries.
 
 [MIT](./LICENSE)
 
-Copyright (c) 2024-2025 ViPro <vdustr@gmail.com> (<http://vdustr.dev>)
+Copyright (c) 2024-2026 ViPro <vdustr@gmail.com> (<https://vdustr.dev>)

--- a/packages/template-vite-react-19/LICENSE
+++ b/packages/template-vite-react-19/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 ViPro <vdustr@gmail.com> (http://vdustr.dev)
+Copyright (c) 2024-2026 ViPro <vdustr@gmail.com> (https://vdustr.dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update copyright year from 2025 to 2026
- Change URLs from HTTP to HTTPS

## Test plan
- [x] All LICENSE files updated
- [x] All README files updated
- [x] Changeset added for version bump

🤖 Generated with [Claude Code](https://claude.ai/code)