### PR TITLE
ci: add stale branch cleanup workflow

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   stale-branches:
     name: Delete Stale Branches
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
## Summary

- Add a daily GitHub Actions workflow to automatically delete remote branches inactive for 7+ days
- Uses [`crs-k/stale-branches@v8.2.2`](https://github.com/crs-k/stale-branches) with `pr-check` enabled to skip branches with open PRs
- Runs daily at 10:00 AM Taiwan time (2:00 AM UTC) with manual dispatch support

## Test plan

- [ ] Verify workflow appears in Actions tab
- [ ] Trigger manually via `workflow_dispatch` to confirm it runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)