### PR TITLE
fix(ci): set days-before-stale less than days-before-delete

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: crs-k/stale-branches@v8.2.2
         with:
-          days-before-stale: 7
+          days-before-stale: 5
           days-before-delete: 7
           pr-check: true


### PR DESCRIPTION
## Summary
- `crs-k/stale-branches` requires `days-before-stale` < `days-before-delete`
- Changed `days-before-stale` from `7` to `5` (delete remains `7`)
- Fixes https://github.com/VdustR/template-aio/actions/runs/23102079481

## Test plan
- [x] YAML syntax validated
- [x] Lint, typecheck all pass
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)