### PR TITLE
fix(ci): add issues write permission for stale branches workflow

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: read
     steps:
       - uses: crs-k/stale-branches@v8.2.2


### PR DESCRIPTION
## Summary
- `crs-k/stale-branches` needs `issues: write` to create stale branch notification issues
- Adding explicitly to prevent failures under stricter token policies
- Ref: https://github.com/chatbotgang/Zeffiroso/actions/runs/23126252323

## Test plan
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)